### PR TITLE
Fix incorrect tax calculation in webhook order creation

### DIFF
--- a/controllers/front/webhook.php
+++ b/controllers/front/webhook.php
@@ -86,8 +86,26 @@ class WorldlineopWebhookModuleFrontController extends ModuleFrontController
         if ($cartId) {
             $cart = new Cart($cartId);
             if (Validate::isLoadedObject($cart)) {
+                // Initialize complete context for correct tax calculation
                 $currency = new Currency($cart->id_currency);
                 $this->context->currency = $currency;
+                
+                // Load customer to ensure proper tax rules are applied
+                $customer = new Customer($cart->id_customer);
+                if (Validate::isLoadedObject($customer)) {
+                    $this->context->customer = $customer;
+                }
+                
+                // Load cart to context to ensure tax calculation based on cart addresses
+                $this->context->cart = $cart;
+                
+                // Load country from invoice address for tax calculation
+                if ($cart->id_address_invoice) {
+                    $invoiceAddress = new Address($cart->id_address_invoice);
+                    if (Validate::isLoadedObject($invoiceAddress)) {
+                        $this->context->country = new Country($invoiceAddress->id_country);
+                    }
+                }
             }
         }
 

--- a/src/Presenter/GetPaymentPresenter.php
+++ b/src/Presenter/GetPaymentPresenter.php
@@ -122,6 +122,26 @@ class GetPaymentPresenter implements PresenterInterface
             return $this->presentedData;
         }
         $idShop = $this->cart->id_shop;
+
+        // Initialize context for proper tax calculation (especially important for webhooks)
+        $context = \Context::getContext();
+        if (!isset($context->cart) || $context->cart->id != $this->cart->id) {
+            $context->cart = $this->cart;
+            $context->currency = new \Currency($this->cart->id_currency);
+            
+            $customer = new \Customer($this->cart->id_customer);
+            if (\Validate::isLoadedObject($customer)) {
+                $context->customer = $customer;
+            }
+            
+            if ($this->cart->id_address_invoice) {
+                $invoiceAddress = new \Address($this->cart->id_address_invoice);
+                if (\Validate::isLoadedObject($invoiceAddress)) {
+                    $context->country = new \Country($invoiceAddress->id_country);
+                }
+            }
+        }
+
         $settings = $this->settingsLoader->setContext($idShop);
         $this->merchantClientFactory->setSettings($settings);
         $idOrder = Order::getIdByCartId($this->cart->id);


### PR DESCRIPTION
🔗 Related Issue
Fixes #20 

📋 Description
This PR fixes a bug where orders created via webhook used incorrect tax rates, causing order amounts to differ from the payment amount received from Worldline.

Root cause: When processing webhooks, the PrestaShop context was incomplete (missing customer, cart, and country), causing Cart::getOrderTotal() to calculate taxes using shop default rates instead of customer-specific tax rules.

Solution: Properly initialize the complete context (customer, cart, invoice address country) before order creation in the webhook flow.

🔄 Changes

[webhook.php]: Initialize customer, cart and country in context when processing payment webhooks
[GetPaymentPresenter.php]: Add context initialization as a safety fallback to ensure proper tax calculation

✅ Impact

Orders created via webhook now use the same tax calculation as orders created via redirect flow
Custom tax rules (reduced rates, country-specific rates) are correctly applied
Order amounts match the payment amount received from Worldline

🧪 Testing

Tested with:

Orders using custom tax rules (e.g., 0% VAT)
Orders with country-specific tax rates
Both webhook and redirect flows produce identical order amounts

📝 Notes

This only affects orders created via webhooks. Orders created via redirect flow were already working correctly as the customer session provides the complete context automatically.